### PR TITLE
Override fixed data table styling to remove padding in cell content

### DIFF
--- a/src/settings/ctr-google-spreadsheet-settings.js
+++ b/src/settings/ctr-google-spreadsheet-settings.js
@@ -29,14 +29,19 @@ angular.module( "risevision.widget.googleSpreadsheet.settings" )
         googleSheet.getWorkSheets( fileId )
           .then( function( sheets ) {
             $scope.public = true;
-            $scope.sheets = sheets;
+            $scope.sheets = sheets.map( function( sheet ) {
+              return {
+                label: sheet.properties.title,
+                value: sheet.properties.title
+              };
+            } );
 
             if ( $scope.settings.additionalParams.spreadsheet.sheetName ) {
-              $scope.currentSheet = sheets.filter( function( obj ) {
+              $scope.currentSheet = $scope.sheets.filter( function( obj ) {
                 return obj.value === $scope.settings.additionalParams.spreadsheet.sheetName;
               } )[ 0 ];
             } else {
-              $scope.currentSheet = sheets[ 0 ];
+              $scope.currentSheet = $scope.sheets[ 0 ];
             }
           } )
           .then( null, function() {

--- a/src/settings/svc-google-sheet.js
+++ b/src/settings/svc-google-sheet.js
@@ -7,17 +7,6 @@ angular.module( "risevision.widget.googleSpreadsheet.settings" )
       var factory = {},
         columnsRequest = null,
         columnsRequestSuccess = true,
-        filterSheets = function( sheets ) {
-          var option;
-
-          return sheets.map( function( sheet ) {
-            option = {};
-
-            option.label = option.value = sheet.properties.title;
-
-            return option;
-          } );
-        },
         getColumnName = function( index ) {
           var ordA = "a".charCodeAt( 0 ),
             ordZ = "z".charCodeAt( 0 ),
@@ -61,9 +50,6 @@ angular.module( "risevision.widget.googleSpreadsheet.settings" )
         return $http.get( api )
           .then( function( response ) {
             return response.data.sheets;
-          } )
-          .then( function( sheets ) {
-            return filterSheets( sheets );
           } );
       };
 

--- a/src/widget/css/fixed-data-table-overrides.css
+++ b/src/widget/css/fixed-data-table-overrides.css
@@ -59,3 +59,10 @@
 .fixedDataTableLayout_bottomShadow {
   visibility: hidden;
 }
+
+/* Remove Cell Padding */
+/************************/
+
+.public_fixedDataTableCell_cellContent {
+  padding: 0;
+}

--- a/test/integration/main.html
+++ b/test/integration/main.html
@@ -111,6 +111,11 @@
         assert.equal(backgroundColor, "rgba(255, 255, 255, 0)");
       });
 
+      test("should enforce no padding in cells", function() {
+        var padding = window.getComputedStyle(document.querySelector(".header_font-style .fixedDataTableCellLayout_wrap3 > div")).getPropertyValue( "padding" );
+        assert.equal(padding, "0px");
+      });
+
       test("should set the even row style of the table", function(done) {
 
         var check = function(done) {

--- a/test/unit/settings/svc-google-sheet-spec.js
+++ b/test/unit/settings/svc-google-sheet-spec.js
@@ -54,16 +54,7 @@ describe( "getWorkSheets", function() {
         expect( results ).be.defined;
         expect( results.length ).to.equal( 2 );
 
-        expect( results[ 0 ] ).to.deep.equal( {
-          "label": "Worksheet 1",
-          "value": "Worksheet 1"
-        } );
-
-        expect( results[ 1 ] ).to.deep.equal( {
-          "label": "Worksheet 2",
-          "value": "Worksheet 2"
-        } );
-
+        expect( results ).to.deep.equal( successData.sheets );
       } );
 
       httpBackend.flush();


### PR DESCRIPTION
- Improved `getWorkSheets()` function in settings sheets service to only provide data from API and have controller configure objects for `select` element
- Removed cell content padding which fixes issue #254 