### PR TITLE
Remove border around main table to avoid overlap issue [stage-2]

### DIFF
--- a/src/widget/css/fixed-data-table-overrides.css
+++ b/src/widget/css/fixed-data-table-overrides.css
@@ -23,8 +23,12 @@
   border-color: transparent;
 }
 
+.fixedDataTableCellGroupLayout_cellGroup .fixedDataTableCellLayout_main:last-of-type {
+  border-right-color: transparent !important;
+}
+
 .fixedDataTableLayout_main {
-  border-color: transparent;
+  border: none;
 }
 
 .public_fixedDataTable_header,

--- a/test/integration/main.html
+++ b/test/integration/main.html
@@ -134,6 +134,11 @@
         };
         check(done);
       });
+
+      test( "should apply no border to main table", function() {
+        var val = window.getComputedStyle(document.querySelector(".fixedDataTableLayout_main")).getPropertyValue( "border-width" );
+        assert.equal(val, "0px");
+      } );
     });
 
     suite("Vertical Alignment", function() {
@@ -168,6 +173,14 @@
         var val = window.getComputedStyle(document.querySelector(".public_fixedDataTable_header")).getPropertyValue( "border-color" );
         assert.equal(val, "rgb(238, 238, 238)");
       });
+
+      test( "should hide the last column separator of table", function() {
+        var val1 = window.getComputedStyle(document.querySelector(".fixedDataTableCellGroupLayout_cellGroup .fixedDataTableCellLayout_main")).getPropertyValue( "border-right-color" ),
+          val2 = window.getComputedStyle(document.querySelector(".fixedDataTableCellGroupLayout_cellGroup .fixedDataTableCellLayout_main:last-of-type")).getPropertyValue( "border-right-color" );
+
+        assert.equal( val1, "rgb(238, 238, 238)" );
+        assert.equal( val2, "rgba(0, 0, 0, 0)" );
+      } );
 
     });
 


### PR DESCRIPTION
- Remove main table border completely and ensure a cell right border of last column is always transparent, fixes issue #259 
- Integration tests added