### PR TITLE
Hide scrollbars for header table

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -49,6 +49,7 @@
     "angular": "~1.3.0",
     "angular-mocks": "~1.3.0",
     "gsap": "~1.18.5",
-    "jquery": "~2.1.1"
+    "jquery": "~2.1.1",
+    "rv-common-style": "v1.3.65"
   }
 }

--- a/src/widget/components/TableHeader.jsx
+++ b/src/widget/components/TableHeader.jsx
@@ -11,7 +11,9 @@ const TableHeader = React.createClass( {
         rowsCount={0}
         width={this.props.width}
         height={this.props.height}
-        headerHeight={this.props.height}>
+        headerHeight={this.props.height}
+        overflowY="hidden"
+        overflowX="hidden">
         {this.props.children}
       </Table>
     );

--- a/test/unit/widget/TableHeader.jsx
+++ b/test/unit/widget/TableHeader.jsx
@@ -41,6 +41,14 @@ describe( "<TableHeader />", function() {
       expect( wrapper.props().headerHeight ).to.equal( height );
     } );
 
+    it("Should have overflowX prop", function() {
+      expect(wrapper.props().overflowX).to.equal("hidden");
+    });
+
+    it("Should have overflowY prop", function() {
+      expect(wrapper.props().overflowY).to.equal("hidden");
+    });
+
     it( "Should render children", function() {
       expect( wrapper.contains( <Column /> ) ).to.equal( true );
     } );


### PR DESCRIPTION
- Resolving bower conflict for `common-style`dependency
- Fixing issue #261 by hiding scrollbars in header table
- Unit tests added