### PR TITLE
Fix applying row colours [stage-2]

### DIFF
--- a/src/widget/components/spreadsheet.jsx
+++ b/src/widget/components/spreadsheet.jsx
@@ -114,8 +114,8 @@ const prefs = new gadgets.Prefs(),
 
     setRowStyle: function() {
       Common.addCSSRules( [
-        ".even" + " div * {background-color: " + params.format.evenRowColor + " !important }",
-        ".odd" + " div * {background-color: " + params.format.oddRowColor + " !important }"
+        ".even" + " .fixedDataTableCellGroupLayout_cellGroup {background-color: " + params.format.evenRowColor + " !important }",
+        ".odd" + " .fixedDataTableCellGroupLayout_cellGroup {background-color: " + params.format.oddRowColor + " !important }"
       ] );
     },
 

--- a/src/widget/css/fixed-data-table-overrides.css
+++ b/src/widget/css/fixed-data-table-overrides.css
@@ -1,6 +1,10 @@
 /* Apply transparent background colors by default */
 /**************************************************/
 
+.public_fixedDataTableCell_main {
+  background-color: transparent;
+}
+
 .public_fixedDataTable_header,
 .public_fixedDataTable_header .public_fixedDataTableCell_main {
   background-color: transparent;

--- a/test/integration/main.html
+++ b/test/integration/main.html
@@ -107,7 +107,7 @@
       });
 
       test("should set the odd row style of the table", function() {
-        var backgroundColor = window.getComputedStyle(document.querySelector(".odd .fixedDataTableCellLayout_wrap1")).getPropertyValue( "background-color" );
+        var backgroundColor = window.getComputedStyle(document.querySelector(".odd .fixedDataTableCellGroupLayout_cellGroup")).getPropertyValue( "background-color" );
         assert.equal(backgroundColor, "rgba(255, 255, 255, 0)");
       });
 
@@ -119,7 +119,7 @@
       test("should set the even row style of the table", function(done) {
 
         var check = function(done) {
-          var element = document.querySelector(".even .fixedDataTableCellLayout_wrap1");
+          var element = document.querySelector(".even .fixedDataTableCellGroupLayout_cellGroup");
 
           if (element) {
             var backgroundColor = window.getComputedStyle(element).getPropertyValue( "background-color" );


### PR DESCRIPTION
- Only applying row background colors to the div containing the group of cells for that row
- Added missing override for ensuring a default transparent background for table cells
- Revised integration test