### PR TITLE
Upgrade font-setting to fix TinyMCE version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -46,8 +46,8 @@
     "responsive-fixed-data-table": "https://github.com/Rise-Vision/responsive-fixed-data-table.git#^3.0.1"
   },
   "resolutions": {
-    "angular": "~1.3.0",
-    "angular-mocks": "~1.3.0",
+    "angular": "~1.4.0",
+    "angular-mocks": "~1.4.x",
     "gsap": "~1.18.5",
     "jquery": "~2.1.1",
     "rv-common-style": "v1.3.65"

--- a/bower.json
+++ b/bower.json
@@ -26,11 +26,11 @@
     "reports"
   ],
   "devDependencies": {
-    "angular-mocks": "~1.3.0",
+    "angular-mocks": "~1.4.x",
     "web-component-tester": "*"
   },
   "dependencies": {
-    "angular": "~1.3.0",
+    "angular": "~1.4.0",
     "angular-bootstrap": "^0.13.0",
     "angular-bootstrap-colorpicker": "~3.0.19",
     "auto-scroll": "https://github.com/Rise-Vision/auto-scroll.git#1.2.0",
@@ -42,7 +42,7 @@
     "webcomponentsjs": "^0.7.22",
     "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.4.4",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.3",
-    "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.2.2",
+    "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.3.0",
     "responsive-fixed-data-table": "https://github.com/Rise-Vision/responsive-fixed-data-table.git#^3.0.1"
   },
   "resolutions": {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,10 +25,10 @@
       "./src/settings.html"
     ],
     vendorFiles = [
-      "./src/components/tinymce-dist/plugins/**/*",
-      "./src/components/tinymce-dist/skins/**/*",
-      "./src/components/tinymce-dist/themes/**/*",
-      "./src/components/tinymce-dist/tinymce*.js",
+      "./src/components/tinymce/plugins/**/*",
+      "./src/components/tinymce/skins/**/*",
+      "./src/components/tinymce/themes/**/*",
+      "./src/components/tinymce/tinymce*.js",
       "./src/components/jquery/dist/**/*",
       "./src/components/angular/angular*.js",
       "./src/components/angular/*.gzip",
@@ -145,7 +145,8 @@
     e2ePicker: "../node_modules/widget-tester/mocks/gapi-picker-mock.js",
     e2eSpreadsheetHTTP: "../test/mocks/google-sheet-http-mock.js",
     e2eTestApp: "../test/e2e/settings-app.js",
-    e2eAppReplace: "../test/e2e/settings-app-replace.js"
+    e2eAppReplace: "../test/e2e/settings-app-replace.js",
+    e2eTinymce: "components/tinymce/tinymce.js"
   } ) );
 
   gulp.task( "e2e:server:settings", [ "config", "html:e2e:settings" ], factory.testServer() );

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#1.7.1"
   },
   "dependencies": {
-    "fixed-data-table": "^0.6.0",
+    "fixed-data-table": "0.6.3",
     "react": "0.14.8",
     "react-dom": "0.14.8",
     "webfontloader": "^1.6.24"

--- a/src/settings.html
+++ b/src/settings.html
@@ -23,15 +23,14 @@
   <!-- FullStory -->
   <script>window['_fs_is_outer_script'] = true; window['_fs_debug'] = false; window['_fs_host'] = 'www.fullstory.com'; window['_fs_org'] = 'U3O'; (function(m,n,e,t,l,o,g,y){ g=m[e]=function(a,b){g.q?g.q.push([a,b]):g._api(a,b);};g.q=[]; o=n.createElement(t);o.async=1;o.src='https://'+_fs_host+'/s/fs.js'; y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y); g.identify=function(i,v){g(l,{uid:i});if(v)g(l,v)};g.setUserVars=function(v){FS(l,v)}; g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;FS(o,v)}; g.clearUserCookie=function(d,i){d=n.domain;while(1){n.cookie='fs_uid=;domain='+d+ ';path=/;expires='+new Date(0);i=d.indexOf('.');if(i<0)break;d=d.slice(i+1)}} })(window,document,'FS','script','user');</script>
 
-  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.20/angular.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.14/angular.min.js"></script>
   <!-- if AngularJS fails to load fallback to a local version -->
   <script>window.angular || document.write(unescape("%3Cscript src='js/vendor/angular/angular.min.js' type='text/javascript'%3E%3C/script%3E"));
   </script>
 
-  <script src="//cdn.tinymce.com/4/tinymce.min.js"></script>
-  <!-- if TinyMCE fails to load fallback to a local version -->
-  <script>window.tinymce || document.write(unescape("%3Cscript src='js/vendor/tinymce-dist/tinymce.min.js' type='text/javascript'%3E%3C/script%3E"));
-  </script>
+  <!-- build:e2eTinymce -->
+  <script src="js/vendor/tinymce/tinymce.min.js"></script>
+  <!-- endbuild -->
 
 </head>
 <body ng-app="risevision.widget.googleSpreadsheet.settings" ng-controller="settingsController">


### PR DESCRIPTION
- Relying on version of TinyMCE from widget-settings-ui-components dependency instead of using CDN
- Upgrading Angular to `1.4.x` to adhere to angular-ui-tinymce requirement
- Force using `0.6.3` of fixed-data-table React component as it recently has been updated after over a year of no activity and latest release caused unit tests to fail