### PR TITLE
Fixes hanging test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "webpack-stream": "^3.2.0",
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#1.7.4"
   },
+  "optionalDependencies": {
+    "wct-local": "<2.0.16"
+  },
   "dependencies": {
     "fixed-data-table": "0.6.3",
     "react": "0.14.8",


### PR DESCRIPTION
As per [this issue](https://github.com/Polymer/web-component-tester/issues/648) with `web-component-tester`. We were using `2.0.16`. 

Changing `web-component-tester` to `6.4.1` would bring on a whole lot of other problems because they seem to have a lot of issues that they're currently trying to solve. I went ahead and changed the `wct-local` to to less than `2.0.16`.