### PR TITLE
Upgrade webcomponentsjs dependency for use of webcomponents-loader

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,7 @@
     "auto-scroll": "https://github.com/Rise-Vision/auto-scroll.git#2.0.1",
     "google-drive-picker": "https://github.com/Rise-Vision/component-google-drive-picker.git#0.1.2",
     "gsap": "~1.18.5",
-    "rise-google-sheet": "https://github.com/Rise-Vision/rise-google-sheet.git#2.4.11",
+    "rise-google-sheet": "https://github.com/Rise-Vision/rise-google-sheet.git#2.4.12",
     "rv-common-i18n": "https://github.com/Rise-Vision/common-i18n.git#1.4.15",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.3.65",
     "webcomponentsjs": "v1.1.0",

--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "rise-google-sheet": "https://github.com/Rise-Vision/rise-google-sheet.git#2.4.11",
     "rv-common-i18n": "https://github.com/Rise-Vision/common-i18n.git#1.4.15",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.3.65",
-    "webcomponentsjs": "^0.7.22",
+    "webcomponentsjs": "v1.1.0",
     "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.4.10",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.3",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.3.0",
@@ -50,6 +50,7 @@
     "angular-mocks": "~1.4.x",
     "gsap": "~1.18.5",
     "jquery": "~2.1.1",
-    "rv-common-style": "v1.3.65"
+    "rv-common-style": "v1.3.65",
+    "webcomponentsjs": "v1.1.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14165,6 +14165,10 @@
         "through2": "2.0.3"
       }
     },
+    "test-fixture": {
+      "version": "github:PolymerElements/test-fixture#7f18951c11307164be6c1502954d2e6b7b20152b",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -15362,6 +15366,7 @@
         "sinon-chai": "2.14.0",
         "socket.io": "1.7.4",
         "stacky": "1.3.1",
+        "test-fixture": "github:PolymerElements/test-fixture#7f18951c11307164be6c1502954d2e6b7b20152b",
         "update-notifier": "0.6.3",
         "wct-local": "2.0.15",
         "wct-sauce": "1.8.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,6 +162,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "optional": true,
       "requires": {
         "extend": "3.0.1",
         "semver": "5.0.3"
@@ -1627,6 +1628,12 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
+    "buffer-from": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+      "dev": true
+    },
     "bufferstreams": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.3.tgz",
@@ -2356,38 +2363,15 @@
       }
     },
     "connect": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.5.tgz",
-      "integrity": "sha1-+43ee6B2OHfQ7J352sC0tA5yx9o=",
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+      "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "finalhandler": "1.0.6",
+        "finalhandler": "1.1.0",
         "parseurl": "1.3.2",
         "utils-merge": "1.0.1"
-      },
-      "dependencies": {
-        "finalhandler": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
-          "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.3.1",
-            "unpipe": "1.0.0"
-          }
-        },
-        "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
-        }
       }
     },
     "connect-history-api-fallback": {
@@ -2470,12 +2454,6 @@
         "request": "2.79.0"
       },
       "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        },
         "js-yaml": {
           "version": "3.6.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
@@ -3461,10 +3439,19 @@
       }
     },
     "es6-promise": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-      "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
       "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "4.2.4"
+      }
     },
     "es6-set": {
       "version": "0.1.5",
@@ -3725,6 +3712,12 @@
         "acorn": "5.3.0",
         "acorn-jsx": "3.0.1"
       }
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
     },
     "esprima-fb": {
       "version": "15001.1.0-dev-harmony-fb",
@@ -4197,24 +4190,27 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
-      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.6.2",
         "debug": "2.6.9",
-        "mkdirp": "0.5.0",
+        "mkdirp": "0.5.1",
         "yauzl": "2.4.1"
       },
       "dependencies": {
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "buffer-from": "1.1.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.3",
+            "typedarray": "0.0.6"
           }
         },
         "yauzl": {
@@ -4245,9 +4241,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -6487,7 +6483,7 @@
       "dependencies": {
         "event-stream": {
           "version": "3.0.20",
-          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.0.20.tgz",
+          "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.0.20.tgz",
           "integrity": "sha1-A4u7LqnqkDhbJvvBhU0LU58qvqM=",
           "dev": true,
           "requires": {
@@ -6579,12 +6575,12 @@
         "dargs": "5.1.0",
         "event-stream": "3.3.4",
         "gulp-util": "2.2.20",
-        "protractor": "5.2.2"
+        "protractor": "5.3.2"
       },
       "dependencies": {
         "event-stream": {
           "version": "3.3.4",
-          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+          "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
           "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
           "dev": true,
           "requires": {
@@ -7655,6 +7651,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "optional": true,
       "requires": {
         "agent-base": "2.1.1",
         "debug": "2.6.9",
@@ -8354,14 +8351,14 @@
       }
     },
     "jasmine": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.9.0.tgz",
-      "integrity": "sha1-dlcfklyHg0CefGFTVy5aY0HPk+s=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
+      "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
       "dev": true,
       "requires": {
         "exit": "0.1.2",
         "glob": "7.1.2",
-        "jasmine-core": "2.9.1"
+        "jasmine-core": "2.8.0"
       },
       "dependencies": {
         "glob": {
@@ -8381,9 +8378,9 @@
       }
     },
     "jasmine-core": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.9.1.tgz",
-      "integrity": "sha1-trvB2OZSUNVvWIhGFwXr7uuI8i8=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
+      "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
       "dev": true
     },
     "jasmine-growl-reporter": {
@@ -8457,9 +8454,9 @@
       }
     },
     "jasmine-reporters": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-2.3.0.tgz",
-      "integrity": "sha1-64y3NZZYVyqH7vSqCIo2MDbzeSo=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-2.3.1.tgz",
+      "integrity": "sha1-9C1XjplmlhY0MdkRwxZ5cZ+0Ozs=",
       "dev": true,
       "requires": {
         "mkdirp": "0.5.1",
@@ -8637,6 +8634,12 @@
           "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
           "dev": true
         },
+        "es6-promise": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+          "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
+          "dev": true
+        },
         "pako": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
@@ -8721,10 +8724,10 @@
         "bluebird": "3.5.1",
         "body-parser": "1.18.2",
         "chokidar": "1.7.0",
-        "colors": "1.1.2",
+        "colors": "1.3.0",
         "combine-lists": "1.0.1",
-        "connect": "3.6.5",
-        "core-js": "2.5.3",
+        "connect": "3.6.6",
+        "core-js": "2.5.7",
         "di": "0.0.1",
         "dom-serialize": "2.2.1",
         "expand-braces": "0.1.2",
@@ -8737,14 +8740,14 @@
         "mime": "1.4.1",
         "minimatch": "3.0.4",
         "optimist": "0.6.1",
-        "qjobs": "1.1.5",
+        "qjobs": "1.2.0",
         "range-parser": "1.2.0",
         "rimraf": "2.6.2",
         "safe-buffer": "5.1.1",
         "socket.io": "1.7.3",
         "source-map": "0.5.7",
         "tmp": "0.0.31",
-        "useragent": "2.2.1"
+        "useragent": "2.3.0"
       },
       "dependencies": {
         "accepts": {
@@ -8758,15 +8761,15 @@
           }
         },
         "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+          "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw==",
           "dev": true
         },
         "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
           "dev": true
         },
         "debug": {
@@ -10227,6 +10230,12 @@
       "dev": true,
       "optional": true
     },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+      "dev": true
+    },
     "nodegit-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/nodegit-promise/-/nodegit-promise-4.0.0.tgz",
@@ -10959,13 +10968,13 @@
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.2",
-        "extract-zip": "1.6.6",
+        "es6-promise": "4.2.4",
+        "extract-zip": "1.6.7",
         "fs-extra": "1.0.0",
         "hasha": "2.2.0",
         "kew": "0.7.0",
         "progress": "1.1.8",
-        "request": "2.83.0",
+        "request": "2.87.0",
         "request-progress": "2.0.1",
         "which": "1.3.0"
       },
@@ -10977,7 +10986,7 @@
           "dev": true,
           "requires": {
             "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
+            "fast-deep-equal": "1.1.0",
             "fast-json-stable-stringify": "2.0.0",
             "json-schema-traverse": "0.3.1"
           }
@@ -10994,56 +11003,32 @@
           "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
           "dev": true
         },
-        "boom": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
         "caseless": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
           "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true
         },
-        "cryptiles": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-          "dev": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-              "dev": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "es6-promise": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.2.tgz",
-          "integrity": "sha512-LSas5vsuA6Q4nEdf9wokY5/AJYXry98i0IzXsv49rYsgDGDNDPbqAYR1Pe23iFxygfbGZNR/5VrHXBCh2BhvUQ==",
-          "dev": true
-        },
         "form-data": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
             "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
+            "combined-stream": "1.0.6",
             "mime-types": "2.1.17"
+          },
+          "dependencies": {
+            "combined-stream": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+              "dev": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            }
           }
         },
         "har-validator": {
@@ -11055,24 +11040,6 @@
             "ajv": "5.5.2",
             "har-schema": "2.0.0"
           }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-          "dev": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-          "dev": true
         },
         "http-signature": {
           "version": "1.2.0",
@@ -11086,15 +11053,15 @@
           }
         },
         "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
         },
         "request": {
-          "version": "2.83.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+          "version": "2.87.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
           "dev": true,
           "requires": {
             "aws-sign2": "0.7.0",
@@ -11103,9 +11070,8 @@
             "combined-stream": "1.0.5",
             "extend": "3.0.1",
             "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
+            "form-data": "2.3.2",
             "har-validator": "5.0.3",
-            "hawk": "6.0.2",
             "http-signature": "1.2.0",
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
@@ -11113,21 +11079,11 @@
             "mime-types": "2.1.17",
             "oauth-sign": "0.8.2",
             "performance-now": "2.1.0",
-            "qs": "6.5.1",
+            "qs": "6.5.2",
             "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
             "tough-cookie": "2.3.3",
             "tunnel-agent": "0.6.0",
             "uuid": "3.2.1"
-          }
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.0"
           }
         },
         "tunnel-agent": {
@@ -12028,9 +11984,9 @@
       "dev": true
     },
     "protractor": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.2.2.tgz",
-      "integrity": "sha512-KxYw0ySvmWFQHpbSRvrHA5HLlyeAkCENSUZvJroKV1u0gWXX9kvHjc9wEK5IoW7h9UfPV1F3R2i+Own0go5s0g==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.3.2.tgz",
+      "integrity": "sha512-pw4uwwiy5lHZjIguxNpkEwJJa7hVz+bJsvaTI+IbXlfn2qXwzbF8eghW/RmrZwE2sGx82I8etb8lVjQ+JrjejA==",
       "dev": true,
       "requires": {
         "@types/node": "6.0.96",
@@ -12039,11 +11995,11 @@
         "blocking-proxy": "1.0.1",
         "chalk": "1.1.3",
         "glob": "7.1.2",
-        "jasmine": "2.9.0",
+        "jasmine": "2.8.0",
         "jasminewd2": "2.2.0",
         "optimist": "0.6.1",
         "q": "1.4.1",
-        "saucelabs": "1.3.0",
+        "saucelabs": "1.5.0",
         "selenium-webdriver": "3.6.0",
         "source-map-support": "0.4.18",
         "webdriver-js-extender": "1.0.0",
@@ -12172,6 +12128,12 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -12183,9 +12145,9 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qjobs": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.1.5.tgz",
-      "integrity": "sha1-ZZ3p8s+NzCehSBJ28gU3cnI4LnM=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
+      "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
       "dev": true
     },
     "qs": {
@@ -12932,12 +12894,42 @@
       }
     },
     "saucelabs": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.3.0.tgz",
-      "integrity": "sha1-0kDoAJ33+ocwbsRXimm6O1xCT+4=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.5.0.tgz",
+      "integrity": "sha512-jlX3FGdWvYf4Q3LFfFWS1QvPg3IGCGWxIc8QBFdPTbpTJnt/v17FHXYVAn7C8sHf1yUXo2c7yIM0isDryfYtHQ==",
       "dev": true,
       "requires": {
-        "https-proxy-agent": "1.0.0"
+        "https-proxy-agent": "2.2.1"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+          "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+          "dev": true,
+          "requires": {
+            "es6-promisify": "5.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+          "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+          "dev": true,
+          "requires": {
+            "agent-base": "4.2.0",
+            "debug": "3.1.0"
+          }
+        }
       }
     },
     "sax": {
@@ -14784,20 +14776,24 @@
       }
     },
     "useragent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
-      "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
       "dev": true,
       "requires": {
-        "lru-cache": "2.2.4",
+        "lru-cache": "4.1.3",
         "tmp": "0.0.30"
       },
       "dependencies": {
         "lru-cache": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
-          "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
-          "dev": true
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
         }
       }
     },
@@ -15848,7 +15844,7 @@
         "gulp-rename": "1.2.2",
         "gulp-util": "2.2.20",
         "jasmine-node": "1.14.5",
-        "jasmine-reporters": "2.3.0",
+        "jasmine-reporters": "2.3.1",
         "junit-xml-parser": "0.0.3",
         "karma": "1.7.1",
         "karma-chai": "0.1.0",
@@ -15992,12 +15988,6 @@
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-          "dev": true
-        },
         "supports-color": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
@@ -16089,13 +16079,13 @@
       "dev": true,
       "requires": {
         "sax": "1.2.4",
-        "xmlbuilder": "9.0.4"
+        "xmlbuilder": "9.0.7"
       },
       "dependencies": {
         "xmlbuilder": {
-          "version": "9.0.4",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
-          "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8=",
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
           "dev": true
         }
       }
@@ -16125,6 +16115,12 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/xunit-file/-/xunit-file-0.0.5.tgz",
       "integrity": "sha1-Ccy3qdinQwAFa7gApkwjQZ7xDfA=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {

--- a/src/widget.html
+++ b/src/widget.html
@@ -7,7 +7,7 @@
 
   <link rel="import" href="components/rise-google-sheet/rise-google-sheet.html">
 
-  <script src="components/webcomponentsjs/webcomponents.min.js"></script>
+  <script src="components/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="components/webfontloader/webfontloader.js"></script>
 </head>
 <body>

--- a/src/widget.html
+++ b/src/widget.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Google Spreadsheet Widget</title>
 
+  <script src="components/webcomponentsjs/webcomponents-loader.js"></script>
   <link rel="import" href="components/rise-google-sheet/rise-google-sheet.html">
 
-  <script src="components/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="components/webfontloader/webfontloader.js"></script>
 </head>
 <body>

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -12,7 +12,5 @@ const React = require( "react" ),
     return false;
   };
 
-  window.addEventListener( "WebComponentsReady", function() {
-    ReactDOM.render( <Main />, document.getElementById( "mainContainer" ) );
-  } );
+  ReactDOM.render( <Main />, document.getElementById( "mainContainer" ) );
 } )( window, document );

--- a/test/integration/api-key-lower-refresh-rate.html
+++ b/test/integration/api-key-lower-refresh-rate.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Spreadsheet Widget</title>
 
-  <script src="../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../src/components/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../src/components/web-component-tester/browser.js"></script>
 
   <link rel="import" href="../../src/components/rise-google-sheet/rise-google-sheet.html">

--- a/test/integration/api-key.html
+++ b/test/integration/api-key.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Spreadsheet Widget</title>
 
-  <script src="../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../src/components/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../src/components/web-component-tester/browser.js"></script>
 
   <link rel="import" href="../../src/components/rise-google-sheet/rise-google-sheet.html">

--- a/test/integration/main.html
+++ b/test/integration/main.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Spreadsheet Widget</title>
 
-  <script src="../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../src/components/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../src/components/web-component-tester/browser.js"></script>
 
   <link rel="import" href="../../src/components/rise-google-sheet/rise-google-sheet.html">

--- a/test/integration/main.html
+++ b/test/integration/main.html
@@ -21,12 +21,145 @@
 <script src="../data/spreadsheet-integration.js"></script>
 <script src="../data/sheets.js"></script>
 <script src="../../node_modules/widget-tester/mocks/gadget-mocks.js"></script>
-<script type="text/javascript" src="../../dist/js/widget.min.js"></script></body>
 
 <script>
 
   let server, paramsStub, clock,
     googleSheet = document.querySelector("rise-google-sheet");
+
+  function startTests() {
+    suite("Spreadsheet Content", function() {
+
+      suiteTeardown(function() {
+        clock.restore();
+        server.restore();
+        googleSheet.$.data.getItem.restore();
+      });
+
+      suite("Initialization", function () {
+        test("should set the width of the container", function() {
+          assert.equal(document.getElementById("mainContainer").style.width, window.innerWidth + "px");
+        });
+
+        test("should set the height of the container", function() {
+          assert.equal(document.getElementById("mainContainer").style.height, window.innerHeight + "px");
+        });
+
+        test("should set the key attribute of the sheets component", function() {
+          assert.equal(document.getElementById("rise-google-sheet").getAttribute("key"), "xxxxxxxxxx");
+        });
+
+        test("should set the sheet attribute of the sheets component", function() {
+          assert.equal(document.getElementById("rise-google-sheet").getAttribute("sheet"), "Sheet1");
+        });
+
+        test("should set the refresh rate of the sheets component", function() {
+          assert.equal(googleSheet.getAttribute("refresh"), window.gadget.settings.additionalParams.spreadsheet.refresh);
+        });
+
+        test("should set the range attribute of the sheets component", function() {
+          assert.equal(document.getElementById("rise-google-sheet").getAttribute("range"), "B2:C3");
+        });
+
+        test("should set the apikey attribute of the sheets component", function() {
+          assert.equal(document.getElementById("rise-google-sheet").getAttribute("apikey"), "AIzaSyAdX5yRzScPWbRm0FnNcoYxbiLeQo8owwc");
+        });
+      });
+
+      suite("Table", function () {
+
+        setup(function() {
+          clock.tick(6000000);
+        });
+
+        test("should set the width of the table header", function() {
+          assert.equal(document.querySelector(".fixedDataTableLayout_main").style.width, window.innerWidth + "px");
+        });
+
+        test("should set the height of the table header", function() {
+          assert.equal(document.querySelector(".fixedDataTableLayout_main").style.height, 50 + "px");
+        });
+
+        test("should set the odd row style of the table", function() {
+          var backgroundColor = window.getComputedStyle(document.querySelector(".odd .fixedDataTableCellGroupLayout_cellGroup")).getPropertyValue( "background-color" );
+          assert.equal(backgroundColor, "rgba(255, 255, 255, 0)");
+        });
+
+        test("should enforce no padding in cells", function() {
+          var padding = window.getComputedStyle(document.querySelector(".header_font-style .fixedDataTableCellLayout_wrap3 > div")).getPropertyValue( "padding" );
+          assert.equal(padding, "0px");
+        });
+
+        test("should set the even row style of the table", function(done) {
+
+          var check = function(done) {
+            var element = document.querySelector(".even .fixedDataTableCellGroupLayout_cellGroup");
+
+            if (element) {
+              var backgroundColor = window.getComputedStyle(element).getPropertyValue( "background-color" );
+              assert.equal(backgroundColor, "rgba(255, 255, 255, 0)");
+              done();
+            }
+            else {
+              setTimeout(function() {
+                check(done)
+              }, 1000);
+            }
+          };
+          check(done);
+        });
+
+        test( "should apply no border to main table", function() {
+          var val = window.getComputedStyle(document.querySelector(".fixedDataTableLayout_main")).getPropertyValue( "border-width" );
+          assert.equal(val, "0px");
+        } );
+      });
+
+      suite("Vertical Alignment", function() {
+
+        test("should set the table header vertical alignment of cells", function() {
+          var verticalAlign = window.getComputedStyle(document.querySelector(".header_font-style .fixedDataTableCellLayout_wrap3")).getPropertyValue( "vertical-align" );
+          assert.equal(verticalAlign, "top");
+        });
+
+        test("should set the table vertical alignment of cells", function() {
+          var verticalAlign = window.getComputedStyle(document.querySelector(".body_font-style .fixedDataTableCellLayout_wrap3")).getPropertyValue( "vertical-align" );
+          assert.equal(verticalAlign, "bottom");
+        });
+
+      });
+
+      suite("Separator", function () {
+
+        test("should set the separator width on table cells", function() {
+          var val1 = window.getComputedStyle(document.querySelector(".fixedDataTableCellLayout_main")).getPropertyValue( "border-width" );
+          var val2 = window.getComputedStyle(document.querySelector(".fixedDataTableCellLayout_main")).getPropertyValue( "border-style" );
+          assert.equal(val1, "0px 1px 1px 0px");
+          assert.equal(val2, "solid");
+        });
+
+        test("should set the separator color of table cells", function() {
+          var val = window.getComputedStyle(document.querySelector(".public_fixedDataTableCell_main")).getPropertyValue( "border-color" );
+          assert.equal(val, "rgb(238, 238, 238)");
+        });
+
+        test("should set the diving separator betweeen header and data tables", function() {
+          var val = window.getComputedStyle(document.querySelector(".public_fixedDataTable_header")).getPropertyValue( "border-color" );
+          assert.equal(val, "rgb(238, 238, 238)");
+        });
+
+        test( "should hide the last column separator of table", function() {
+          var val1 = window.getComputedStyle(document.querySelector(".fixedDataTableCellGroupLayout_cellGroup .fixedDataTableCellLayout_main")).getPropertyValue( "border-right-color" ),
+            val2 = window.getComputedStyle(document.querySelector(".fixedDataTableCellGroupLayout_cellGroup .fixedDataTableCellLayout_main:last-of-type")).getPropertyValue( "border-right-color" );
+
+          assert.equal( val1, "rgb(238, 238, 238)" );
+          assert.equal( val2, "rgba(0, 0, 0, 0)" );
+        } );
+
+      });
+
+    });
+  }
 
   sinon.stub(googleSheet.$.data, "getItem", function(key, cb) {
     cb(null);
@@ -52,141 +185,11 @@
 
     // call it again with the params
     googleSheet.go();
-  });
-
-  suite("Spreadsheet Content", function() {
-
-    suiteTeardown(function() {
-      clock.restore();
-      server.restore();
-      googleSheet.$.data.getItem.restore();
-    });
-
-    suite("Initialization", function () {
-      test("should set the width of the container", function() {
-        assert.equal(document.getElementById("mainContainer").style.width, window.innerWidth + "px");
-      });
-
-      test("should set the height of the container", function() {
-        assert.equal(document.getElementById("mainContainer").style.height, window.innerHeight + "px");
-      });
-
-      test("should set the key attribute of the sheets component", function() {
-        assert.equal(document.getElementById("rise-google-sheet").getAttribute("key"), "xxxxxxxxxx");
-      });
-
-      test("should set the sheet attribute of the sheets component", function() {
-        assert.equal(document.getElementById("rise-google-sheet").getAttribute("sheet"), "Sheet1");
-      });
-
-      test("should set the refresh rate of the sheets component", function() {
-        assert.equal(googleSheet.getAttribute("refresh"), window.gadget.settings.additionalParams.spreadsheet.refresh);
-      });
-
-      test("should set the range attribute of the sheets component", function() {
-        assert.equal(document.getElementById("rise-google-sheet").getAttribute("range"), "B2:C3");
-      });
-
-      test("should set the apikey attribute of the sheets component", function() {
-        assert.equal(document.getElementById("rise-google-sheet").getAttribute("apikey"), "AIzaSyAdX5yRzScPWbRm0FnNcoYxbiLeQo8owwc");
-      });
-    });
-
-    suite("Table", function () {
-
-      setup(function() {
-        clock.tick(6000000);
-      });
-
-      test("should set the width of the table header", function() {
-        assert.equal(document.querySelector(".fixedDataTableLayout_main").style.width, window.innerWidth + "px");
-      });
-
-      test("should set the height of the table header", function() {
-        assert.equal(document.querySelector(".fixedDataTableLayout_main").style.height, 50 + "px");
-      });
-
-      test("should set the odd row style of the table", function() {
-        var backgroundColor = window.getComputedStyle(document.querySelector(".odd .fixedDataTableCellGroupLayout_cellGroup")).getPropertyValue( "background-color" );
-        assert.equal(backgroundColor, "rgba(255, 255, 255, 0)");
-      });
-
-      test("should enforce no padding in cells", function() {
-        var padding = window.getComputedStyle(document.querySelector(".header_font-style .fixedDataTableCellLayout_wrap3 > div")).getPropertyValue( "padding" );
-        assert.equal(padding, "0px");
-      });
-
-      test("should set the even row style of the table", function(done) {
-
-        var check = function(done) {
-          var element = document.querySelector(".even .fixedDataTableCellGroupLayout_cellGroup");
-
-          if (element) {
-            var backgroundColor = window.getComputedStyle(element).getPropertyValue( "background-color" );
-            assert.equal(backgroundColor, "rgba(255, 255, 255, 0)");
-            done();
-          }
-          else {
-            setTimeout(function() {
-              check(done)
-            }, 1000);
-          }
-        };
-        check(done);
-      });
-
-      test( "should apply no border to main table", function() {
-        var val = window.getComputedStyle(document.querySelector(".fixedDataTableLayout_main")).getPropertyValue( "border-width" );
-        assert.equal(val, "0px");
-      } );
-    });
-
-    suite("Vertical Alignment", function() {
-
-      test("should set the table header vertical alignment of cells", function() {
-        var verticalAlign = window.getComputedStyle(document.querySelector(".header_font-style .fixedDataTableCellLayout_wrap3")).getPropertyValue( "vertical-align" );
-        assert.equal(verticalAlign, "top");
-      });
-
-      test("should set the table vertical alignment of cells", function() {
-        var verticalAlign = window.getComputedStyle(document.querySelector(".body_font-style .fixedDataTableCellLayout_wrap3")).getPropertyValue( "vertical-align" );
-        assert.equal(verticalAlign, "bottom");
-      });
-
-    });
-
-    suite("Separator", function () {
-
-      test("should set the separator width on table cells", function() {
-        var val1 = window.getComputedStyle(document.querySelector(".fixedDataTableCellLayout_main")).getPropertyValue( "border-width" );
-        var val2 = window.getComputedStyle(document.querySelector(".fixedDataTableCellLayout_main")).getPropertyValue( "border-style" );
-        assert.equal(val1, "0px 1px 1px 0px");
-        assert.equal(val2, "solid");
-      });
-
-      test("should set the separator color of table cells", function() {
-        var val = window.getComputedStyle(document.querySelector(".public_fixedDataTableCell_main")).getPropertyValue( "border-color" );
-        assert.equal(val, "rgb(238, 238, 238)");
-      });
-
-      test("should set the diving separator betweeen header and data tables", function() {
-        var val = window.getComputedStyle(document.querySelector(".public_fixedDataTable_header")).getPropertyValue( "border-color" );
-        assert.equal(val, "rgb(238, 238, 238)");
-      });
-
-      test( "should hide the last column separator of table", function() {
-        var val1 = window.getComputedStyle(document.querySelector(".fixedDataTableCellGroupLayout_cellGroup .fixedDataTableCellLayout_main")).getPropertyValue( "border-right-color" ),
-          val2 = window.getComputedStyle(document.querySelector(".fixedDataTableCellGroupLayout_cellGroup .fixedDataTableCellLayout_main:last-of-type")).getPropertyValue( "border-right-color" );
-
-        assert.equal( val1, "rgb(238, 238, 238)" );
-        assert.equal( val2, "rgba(0, 0, 0, 0)" );
-      } );
-
-    });
-
+    startTests();
   });
 
 </script>
+<script type="text/javascript" src="../../dist/js/widget.min.js"></script></body>
 
 </body>
 </html>

--- a/test/integration/no-separator.html
+++ b/test/integration/no-separator.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Spreadsheet Widget</title>
 
-  <script src="../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../src/components/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../src/components/web-component-tester/browser.js"></script>
 
   <link rel="import" href="../../src/components/rise-google-sheet/rise-google-sheet.html">

--- a/test/integration/no-separator.html
+++ b/test/integration/no-separator.html
@@ -21,12 +21,55 @@
 <script src="../data/spreadsheet-integration-no-separator.js"></script>
 <script src="../data/sheets.js"></script>
 <script src="../../node_modules/widget-tester/mocks/gadget-mocks.js"></script>
-<script type="text/javascript" src="../../dist/js/widget.min.js"></script></body>
 
 <script>
 
   let server, paramsStub, clock,
     googleSheet = document.querySelector("rise-google-sheet");
+
+  function startTests() {
+    suite("Separator", function() {
+
+      suiteTeardown(function() {
+        clock.restore();
+        server.restore();
+        googleSheet.$.data.getItem.restore();
+      });
+
+      suite("No separator", function () {
+
+        setup(function() {
+          clock.tick(6000000);
+        });
+
+        test("should set the separator width on table cells to be 0", function(done) {
+
+          var check = function(done) {
+            var element = document.querySelector(".public_fixedDataTableCell_main");
+
+            if (element) {
+              var val1 = window.getComputedStyle(document.querySelector(".public_fixedDataTableCell_main")).getPropertyValue( "border-color" );
+              var val2 = window.getComputedStyle(document.querySelector(".public_fixedDataTable_header")).getPropertyValue( "border-color" );
+              var borderValue = window.getComputedStyle(document.querySelector(".public_fixedDataTableCell_main")).getPropertyValue( "border" );
+              assert.equal(val1, "rgb(0, 0, 0)");
+              assert.equal(val2, "rgba(0, 0, 0, 0)");
+              assert.equal(borderValue, "0px none rgb(0, 0, 0)");
+
+              done();
+            }
+            else {
+              setTimeout(function() {
+                check(done)
+              }, 1000);
+            }
+          };
+          check(done);
+
+        });
+
+      });
+    });
+  }
 
   sinon.stub(googleSheet.$.data, "getItem", function(key, cb) {
     cb(null);
@@ -52,51 +95,11 @@
 
     // call it again with the params
     googleSheet.go();
-  });
-
-  suite("Separator", function() {
-
-    suiteTeardown(function() {
-      clock.restore();
-      server.restore();
-      googleSheet.$.data.getItem.restore();
-    });
-
-    suite("No separator", function () {
-
-      setup(function() {
-        clock.tick(6000000);
-      });
-
-      test("should set the separator width on table cells to be 0", function(done) {
-
-        var check = function(done) {
-          var element = document.querySelector(".public_fixedDataTableCell_main");
-
-          if (element) {
-            var val1 = window.getComputedStyle(document.querySelector(".public_fixedDataTableCell_main")).getPropertyValue( "border-color" );
-            var val2 = window.getComputedStyle(document.querySelector(".public_fixedDataTable_header")).getPropertyValue( "border-color" );
-            var borderValue = window.getComputedStyle(document.querySelector(".public_fixedDataTableCell_main")).getPropertyValue( "border" );
-            assert.equal(val1, "rgb(0, 0, 0)");
-            assert.equal(val2, "rgba(0, 0, 0, 0)");
-            assert.equal(borderValue, "0px none rgb(0, 0, 0)");
-
-            done();
-          }
-          else {
-            setTimeout(function() {
-              check(done)
-            }, 1000);
-          }
-        };
-        check(done);
-
-      });
-
-    });
+    startTests();
   });
 
 </script>
+<script type="text/javascript" src="../../dist/js/widget.min.js"></script></body>
 
 </body>
 </html>

--- a/test/integration/scrolling-hasheader.html
+++ b/test/integration/scrolling-hasheader.html
@@ -21,12 +21,35 @@
 <script src="../data/spreadsheet-integration-scroll-hasheader.js"></script>
 <script src="../data/sheets.js"></script>
 <script src="../../node_modules/widget-tester/mocks/gadget-mocks.js"></script>
-<script type="text/javascript" src="../../dist/js/widget.min.js"></script></body>
 
 <script>
 
   let server, paramsStub, clock,
     googleSheet = document.querySelector("rise-google-sheet");
+
+  function startTests() {
+    suite("Scrolling", function() {
+
+      suiteTeardown(function() {
+        clock.restore();
+        server.restore();
+        googleSheet.$.data.getItem.restore();
+      });
+
+      suite("Page - Has Header", function () {
+
+        setup(function () {
+          clock.tick(6000000);
+        });
+
+        test("Should calculate height of section element correctly", function () {
+          assert.equal(document.querySelector("section.page").style.height, "250px");
+        });
+
+      });
+
+    });
+  }
 
   sinon.stub(googleSheet.$.data, "getItem", function(key, cb) {
     cb(null);
@@ -52,31 +75,11 @@
 
     // call it again with the params
     googleSheet.go();
-  });
-
-  suite("Scrolling", function() {
-
-    suiteTeardown(function() {
-      clock.restore();
-      server.restore();
-      googleSheet.$.data.getItem.restore();
-    });
-
-    suite("Page - Has Header", function () {
-
-      setup(function () {
-        clock.tick(6000000);
-      });
-
-      test("Should calculate height of section element correctly", function () {
-        assert.equal(document.querySelector("section.page").style.height, "250px");
-      });
-
-    });
-
+    startTests();
   });
 
 </script>
+<script type="text/javascript" src="../../dist/js/widget.min.js"></script></body>
 
 </body>
 </html>

--- a/test/integration/scrolling-hasheader.html
+++ b/test/integration/scrolling-hasheader.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Spreadsheet Widget</title>
 
-  <script src="../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../src/components/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../src/components/web-component-tester/browser.js"></script>
 
   <link rel="import" href="../../src/components/rise-google-sheet/rise-google-sheet.html">

--- a/test/integration/scrolling-noheader.html
+++ b/test/integration/scrolling-noheader.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Spreadsheet Widget</title>
 
-  <script src="../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../src/components/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../src/components/web-component-tester/browser.js"></script>
 
   <link rel="import" href="../../src/components/rise-google-sheet/rise-google-sheet.html">

--- a/test/integration/scrolling-noheader.html
+++ b/test/integration/scrolling-noheader.html
@@ -21,12 +21,35 @@
 <script src="../data/spreadsheet-integration-scroll-noheader.js"></script>
 <script src="../data/sheets.js"></script>
 <script src="../../node_modules/widget-tester/mocks/gadget-mocks.js"></script>
-<script type="text/javascript" src="../../dist/js/widget.min.js"></script></body>
 
 <script>
 
   let server, paramsStub, clock,
     googleSheet = document.querySelector("rise-google-sheet");
+
+  function startTests() {
+    suite("Scrolling", function() {
+
+      suiteTeardown(function() {
+        clock.restore();
+        server.restore();
+        googleSheet.$.data.getItem.restore()
+      });
+
+      suite("Page - No Header", function () {
+
+        setup(function() {
+          clock.tick(6000000);
+        });
+
+        test("Should calculate height of section element correctly", function() {
+          assert.equal(document.querySelector("section.page").style.height, "250px");
+        });
+
+      });
+
+    });
+  }
 
   sinon.stub(googleSheet.$.data, "getItem", function(key, cb) {
     cb(null);
@@ -52,31 +75,11 @@
 
     // call it again with the params
     googleSheet.go();
-  });
-
-  suite("Scrolling", function() {
-
-    suiteTeardown(function() {
-      clock.restore();
-      server.restore();
-      googleSheet.$.data.getItem.restore()
-    });
-
-    suite("Page - No Header", function () {
-
-      setup(function() {
-        clock.tick(6000000);
-      });
-
-      test("Should calculate height of section element correctly", function() {
-        assert.equal(document.querySelector("section.page").style.height, "250px");
-      });
-
-    });
-
+    startTests();
   });
 
 </script>
+<script type="text/javascript" src="../../dist/js/widget.min.js"></script></body>
 
 </body>
 </html>

--- a/test/integration/scrolling-pud.html
+++ b/test/integration/scrolling-pud.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Spreadsheet Widget</title>
 
-  <script src="../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../src/components/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../src/components/web-component-tester/browser.js"></script>
 
   <link rel="import" href="../../src/components/rise-google-sheet/rise-google-sheet.html">

--- a/test/integration/scrolling-pud.html
+++ b/test/integration/scrolling-pud.html
@@ -21,12 +21,36 @@
 <script src="../data/spreadsheet-integration-pud.js"></script>
 <script src="../data/sheets.js"></script>
 <script src="../../node_modules/widget-tester/mocks/gadget-mocks.js"></script>
-<script type="text/javascript" src="../../dist/js/widget.min.js"></script></body>
 
 <script>
 
   let server, paramsStub, clock,
     googleSheet = document.querySelector("rise-google-sheet");
+
+  function startTests() {
+    suite("PUD timer", function () {
+      let rpcSpy = null;
+
+      suiteSetup(function() {
+        rpcSpy = sinon.spy(gadgets.rpc, "call");
+      });
+
+      suiteTeardown(function() {
+        clock.restore();
+        server.restore();
+        rpcSpy.restore();
+        googleSheet.$.data.getItem.restore();
+      });
+
+      test("should send Done after seconds specified by PUD Failover", function() {
+        clock.tick(4000);
+        assert.equal(rpcSpy.callCount, 0);
+
+        clock.tick(1000);
+        assert.equal(rpcSpy.callCount, 1);
+      });
+    });
+  }
 
   sinon.stub(googleSheet.$.data, "getItem", function(key, cb) {
     cb(null);
@@ -45,32 +69,11 @@
 
     googleSheet._onDataPingReceived();
     googleSheet.go();
-  });
-
-  suite("PUD timer", function () {
-    let rpcSpy = null;
-
-    suiteSetup(function() {
-      rpcSpy = sinon.spy(gadgets.rpc, "call");
-    });
-
-    suiteTeardown(function() {
-      clock.restore();
-      server.restore();
-      rpcSpy.restore();
-      googleSheet.$.data.getItem.restore();
-    });
-
-    test("should send Done after seconds specified by PUD Failover", function() {
-      clock.tick(4000);
-      assert.equal(rpcSpy.callCount, 0);
-
-      clock.tick(1000);
-      assert.equal(rpcSpy.callCount, 1);
-    });
+    startTests();
   });
 
 </script>
+<script type="text/javascript" src="../../dist/js/widget.min.js"></script></body>
 
 </body>
 </html>

--- a/test/integration/scrolling-zero-pud.html
+++ b/test/integration/scrolling-zero-pud.html
@@ -21,12 +21,36 @@
 <script src="../data/spreadsheet-integration-zero-pud.js"></script>
 <script src="../data/sheets.js"></script>
 <script src="../../node_modules/widget-tester/mocks/gadget-mocks.js"></script>
-<script type="text/javascript" src="../../dist/js/widget.min.js"></script></body>
 
 <script>
 
   let server, paramsStub, clock,
     googleSheet = document.querySelector("rise-google-sheet");
+
+  function startTests() {
+    suite("PUD timer", function () {
+      let rpcSpy = null;
+
+      suiteSetup(function() {
+        rpcSpy = sinon.spy(gadgets.rpc, "call");
+      });
+
+      suiteTeardown(function() {
+        clock.restore();
+        server.restore();
+        rpcSpy.restore();
+        googleSheet.$.data.getItem.restore();
+      });
+
+      test("should send Done after 10 seconds if PUD Failover < 1", function() {
+        clock.tick(9000);
+        assert.equal(rpcSpy.callCount, 0);
+
+        clock.tick(1000);
+        assert.equal(rpcSpy.callCount, 1);
+      });
+    });
+  }
 
   sinon.stub(googleSheet.$.data, "getItem", function(key, cb) {
     cb(null);
@@ -45,32 +69,11 @@
 
     googleSheet._onDataPingReceived();
     googleSheet.go();
-  });
-
-  suite("PUD timer", function () {
-    let rpcSpy = null;
-
-    suiteSetup(function() {
-      rpcSpy = sinon.spy(gadgets.rpc, "call");
-    });
-
-    suiteTeardown(function() {
-      clock.restore();
-      server.restore();
-      rpcSpy.restore();
-      googleSheet.$.data.getItem.restore();
-    });
-
-    test("should send Done after 10 seconds if PUD Failover < 1", function() {
-      clock.tick(9000);
-      assert.equal(rpcSpy.callCount, 0);
-
-      clock.tick(1000);
-      assert.equal(rpcSpy.callCount, 1);
-    });
+    startTests();
   });
 
 </script>
+<script type="text/javascript" src="../../dist/js/widget.min.js"></script>
 
 </body>
 </html>

--- a/test/integration/scrolling-zero-pud.html
+++ b/test/integration/scrolling-zero-pud.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Spreadsheet Widget</title>
 
-  <script src="../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../src/components/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../src/components/web-component-tester/browser.js"></script>
 
   <link rel="import" href="../../src/components/rise-google-sheet/rise-google-sheet.html">


### PR DESCRIPTION
- Forcing to use latest [webcomponentsjs](https://github.com/webcomponents/webcomponentsjs) dependency to be able to use `webcomponents-loader.js` synchronously
- Removed listening for _WebComponentsReady_ as using `webcomponents-loader.js` synchronously does not require it. This fixes the issue on Preview in Chrome 67 (just released) because that _WebComponentsReady_ event is not getting fired from previous `webcomponents-lite.js` polyfill of older version of _webcomponentsjs_ dependency. 
- Had to revise all integration tests to account for `setAdditionalParams()`now being executed prior to stubbing the function for test purposes. 
- Upgraded `rise-google-sheet` to include upgraded child components (rise-data & rise-logger) to implement the workaround of leveraging "ready" hook instead of "attached".