### PR TITLE
Chore/deploy to gcs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,6 @@ jobs:
   setup:
     working_directory: ~/Rise-Vision/widget-google-spreadsheet
     shell: /bin/bash --login
-    environment:
-      awscli: /home/ubuntu/aws/bin/aws
     docker: *BUILDIMAGE
     steps:
       - checkout
@@ -162,7 +160,7 @@ jobs:
             echo Deploying version $(grep version package.json |grep -o '[0-9.]*') to $BUCKET_NAME-test/stage-0-dev
             STAGE_ENV='stage-0-dev'
           fi
-          gsutil rsync -d -r test_dist gs://rise-content/$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist
+          gsutil rsync -d -r test_dist gs://widgets.risevision.com/$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist
 
   stage-aws-prod:
     shell: /bin/bash --login
@@ -205,9 +203,9 @@ jobs:
             echo Deploying version $(grep version package.json |grep -o '[0-9.]*') to $BUCKET_NAME-test/stage-0
             STAGE_ENV='stage-0'
           fi
-          gsutil rsync -d -r dist gs://rise-content/$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist
-          gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" gs://rise-content/$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist
-          gsutil acl -r ch -u AllUsers:R gs://rise-content/$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist
+          gsutil rsync -d -r dist gs://widgets.risevision.com/$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist
+          gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" gs://widgets.risevision.com/$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist
+          gsutil acl -r ch -u AllUsers:R gs://widgets.risevision.com/$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist
 
   deploy-aws-stable:
     shell: /bin/bash --login
@@ -234,9 +232,9 @@ jobs:
       - run: mkdir -p ~/.config
       - run: cp -r gcloud ~/.config
       - run: echo Deploying version $(grep version package.json |grep -o '[0-9.]*') to $BUCKET_NAME
-      - run: gsutil rsync -d -r dist gs://rise-content/$BUCKET_NAME/$(grep version package.json |grep -o '[0-9.]*')/dist
-      - run: gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" gs://rise-content/$BUCKET_NAME/$(grep version package.json |grep -o '[0-9.]*')/dist
-      - run: gsutil acl -r ch -u AllUsers:R gs://rise-content/$BUCKET_NAME/$(grep version package.json |grep -o '[0-9.]*')/dist
+      - run: gsutil rsync -d -r dist gs://widgets.risevision.com/$BUCKET_NAME/$(grep version package.json |grep -o '[0-9.]*')/dist
+      - run: gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" gs://widgets.risevision.com/$BUCKET_NAME/$(grep version package.json |grep -o '[0-9.]*')/dist
+      - run: gsutil acl -r ch -u AllUsers:R gs://widgets.risevision.com/$BUCKET_NAME/$(grep version package.json |grep -o '[0-9.]*')/dist
       - run: ./upload-dist.sh
 
   test-memory:

--- a/src/widget.html
+++ b/src/widget.html
@@ -13,6 +13,16 @@
 <body>
 
   <div id="mainContainer"></div>
+  
+  <script>
+    if (document.domain.indexOf("localhost") === -1) {
+      try {
+        document.domain = "risevision.com";
+      } catch (err) {
+        // can't set document.domain, risevision.com not an accepted suffix of current document domain
+      }
+    }
+  </script>
 
   <rise-google-sheet id="rise-google-sheet" usage="widget"></rise-google-sheet>
 


### PR DESCRIPTION
Manually tested settings and widget.

GCS deployment created in following bucket:

https://console.cloud.google.com/storage/browser/widgets.risevision.com/widget-google-spreadsheet-test/?project=avid-life-623