### PR TITLE
Enforce minimum 10 minute refresh rate for custom API key usage

### DIFF
--- a/src/settings.html
+++ b/src/settings.html
@@ -214,6 +214,15 @@
               </div>
             </div>
 
+
+            <div ng-if="!validCustomApiKeyInterval">
+              <div class="content-box add-bottom">
+                <div class="bg-danger add-padding">
+                  <span>The minimum refresh interval is 10 minutes when using your own API key.</span>
+                </div>
+              </div>
+            </div>
+
             <hr>
           </div>
     <!-- END REFRESH INTERVAL -->

--- a/src/settings/ctr-google-spreadsheet-settings.js
+++ b/src/settings/ctr-google-spreadsheet-settings.js
@@ -7,6 +7,7 @@ angular.module( "risevision.widget.googleSpreadsheet.settings" )
       $scope.currentSheet = null;
       $scope.columns = [];
       $scope.validApiKey = true;
+      $scope.validCustomApiKeyInterval = true;
       $scope.public = true;
       $scope.validData = true;
 
@@ -216,6 +217,17 @@ angular.module( "risevision.widget.googleSpreadsheet.settings" )
             $scope.settings.additionalParams.spreadsheet.refresh = 60;
           }
         }
+      } );
+
+      $scope.$watch( "settings.additionalParams.spreadsheet.refresh", function( newVal ) {
+        var isValid = true;
+
+        if ( $scope.settings.additionalParams.spreadsheet.apiKey ) {
+          isValid = ( newVal && newVal > 10 ) ? true : false;
+        }
+
+        $scope.validCustomApiKeyInterval = isValid;
+        $scope.settingsForm.$setValidity( "refresh", isValid );
       } );
 
       $scope.$watch( "validApiKey", function( newVal, oldVal ) {

--- a/src/settings/ctr-google-spreadsheet-settings.js
+++ b/src/settings/ctr-google-spreadsheet-settings.js
@@ -223,7 +223,7 @@ angular.module( "risevision.widget.googleSpreadsheet.settings" )
         var isValid = true;
 
         if ( $scope.settings.additionalParams.spreadsheet.apiKey ) {
-          isValid = ( newVal && newVal > 10 ) ? true : false;
+          isValid = ( newVal && newVal >= 10 ) ? true : false;
         }
 
         $scope.validCustomApiKeyInterval = isValid;

--- a/src/widget/components/spreadsheet.jsx
+++ b/src/widget/components/spreadsheet.jsx
@@ -195,10 +195,13 @@ const prefs = new gadgets.Prefs(),
         }
       }
 
-      if ( params.spreadsheet.apiKey ) {
+      if ( params.spreadsheet.apiKey && params.spreadsheet.apiKey !== this.API_KEY_DEFAULT ) {
         sheetParams.apikey = params.spreadsheet.apiKey;
-      } else if ( params.spreadsheet.refresh < 60 ) {
-        sheetParams.refresh = 60;
+        // force a minimum 10 min refresh for custom API key
+        sheetParams.refresh = params.spreadsheet.refresh < 10 ? 10 : params.spreadsheet.refresh;
+      } else {
+        // ensure a minimum 60 min refresh for RiseVision API key
+        sheetParams.refresh = params.spreadsheet.refresh < 60 ? 60 : params.spreadsheet.refresh;
       }
 
       sheet = new RiseGoogleSheet( sheetParams, riseData, this.handleGoogleSheet );


### PR DESCRIPTION
## Description
Validates refresh value input in Settings UI when custom API key used. Shows UI error message and disables Saving when value is < 10. 

In the widget now enforcing no lower than 10 minute refresh rate for custom API key usage to account for existing presentations with value that is lower than 10. 

## Motivation and Context
Fixes issue #321 

## How Has This Been Tested?
Validated locally and with a staged widget - https://apps.risevision.com/editor/workspace/70132ef6-9237-4a51-a217-50cf9d3faa9a?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

Validated all endpoints. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
