### PR TITLE
Stop displaying error messages on screen and skip immediately

### DIFF
--- a/src/widget/components/spreadsheet.jsx
+++ b/src/widget/components/spreadsheet.jsx
@@ -298,6 +298,7 @@ const prefs = new gadgets.Prefs(),
       this.logEvent( {
         "event": "error",
         "event_details": "api quota exceeded",
+        "error_details": detail.status && detail.statusText ? `${detail.status}: ${detail.statusText}` : "",
         "url": params.spreadsheet.url,
         "api_key": ( params.spreadsheet.apiKey ) ? params.spreadsheet.apiKey : this.API_KEY_DEFAULT
       } );


### PR DESCRIPTION
## Description
No longer displaying a message that correlates to an error situation. Now ensuring to immediately call `done()` and effectively have Viewer skip the widget instance in the placeholder playlist. 

Also includes the following improvements:

- Logging a warning when Widget is running on a legacy Rise Player - previously we displayed a message but did not log to BQ. 
- Logging a _warning_ event for a Sheets API server error (50x status) - previously we were not logging to BQ at all.
- Including `error_details` value when logging a quota exceeded error, which will provide `statusText` and might be helpful if it indicates which type of quota threshold was exceeded. 

## Motivation and Context
Displays should not be displaying error messages

## How Has This Been Tested?
Describe in detail how you tested your changes. Include details of your testing environment and link(s) for reviewers to validate.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
