### PR TITLE
Use latest widget-common commit

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "gsap": "~1.18.5",
     "jquery": "~3.3.1",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.3.65",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#fix/issue-321",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#55c9c078",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.3",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.3.0",
     "responsive-fixed-data-table": "https://github.com/Rise-Vision/responsive-fixed-data-table.git#^3.1.0"
@@ -52,6 +52,6 @@
     "jquery": "~3.3.1",
     "lodash": "~4.17.4",
     "rv-common-style": "v1.3.65",
-    "widget-common": "fix/issue-321"
+    "widget-common": "55c9c078"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "gsap": "~1.18.5",
     "jquery": "~3.3.1",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.3.65",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.11.0",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#fix/issue-321",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.3",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.3.0",
     "responsive-fixed-data-table": "https://github.com/Rise-Vision/responsive-fixed-data-table.git#^3.1.0"
@@ -52,6 +52,6 @@
     "jquery": "~3.3.1",
     "lodash": "~4.17.4",
     "rv-common-style": "v1.3.65",
-    "widget-common": "v3.10.0"
+    "widget-common": "fix/issue-321"
   }
 }


### PR DESCRIPTION
## Description
Target the latest widget-common branch code that implements delaying execution of Sheets API requests.

PR for widget-common is https://github.com/Rise-Vision/widget-common/pull/165

## Motivation and Context
Test out fixing issue #321 

## How Has This Been Tested?
Tested with a staged version of Widget that uses latest commit from this branch, see presentation https://apps.risevision.com/editor/workspace/25cc9250-e962-4d5d-bf66-0432074a9c6e?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

Tested in Preview and on display.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
