### PR TITLE
Stop displaying errors and randomize execution of Sheets API requests 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "gsap": "~1.18.5",
     "jquery": "~3.3.1",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.3.65",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#55c9c078",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.12.2",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.3",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.3.0",
     "responsive-fixed-data-table": "https://github.com/Rise-Vision/responsive-fixed-data-table.git#^3.1.0"
@@ -51,7 +51,6 @@
     "angular-ui-router": "^0.2.18",
     "jquery": "~3.3.1",
     "lodash": "~4.17.4",
-    "rv-common-style": "v1.3.65",
-    "widget-common": "55c9c078"
+    "rv-common-style": "v1.3.65"
   }
 }

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -12,5 +12,8 @@ const React = require( "react" ),
     return false;
   };
 
+  // TODO: Fix Issue 321
+  // TODO: Stop displaying error messages
+
   ReactDOM.render( <Main />, document.getElementById( "mainContainer" ) );
 } )( window, document );

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -12,8 +12,5 @@ const React = require( "react" ),
     return false;
   };
 
-  // TODO: Fix Issue 321
-  // TODO: Stop displaying error messages
-
   ReactDOM.render( <Main />, document.getElementById( "mainContainer" ) );
 } )( window, document );


### PR DESCRIPTION
## Description
Complete changes from PRs #326 and #327 which implement:

- Stop displaying error messages and ensure the widget immediately notifies `done` in an error situation
- Delay executing requests to Sheets API by a random integer within the range of:
  - 60 seconds, when no cache is available
  - 180 seconds (3 mins), when cache is available

## Motivation and Context
Fix issue #321 

## How Has This Been Tested?
Tested with staged version of widget in this presentation https://apps.risevision.com/editor/workspace/25cc9250-e962-4d5d-bf66-0432074a9c6e?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f 

Validated in Preview and on a display. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
