### PR TITLE
Report ready without requiring sheet data

### DIFF
--- a/src/widget/components/spreadsheet.jsx
+++ b/src/widget/components/spreadsheet.jsx
@@ -363,9 +363,7 @@ const prefs = new gadgets.Prefs(),
         this.refs.scrollComponent.pause();
       }
 
-      if ( this.pudTimer ) {
-        clearTimeout( this.pudTimer );
-      }
+      this.cancelPUDTimer();
     },
 
     stop: function() {

--- a/src/widget/components/spreadsheet.jsx
+++ b/src/widget/components/spreadsheet.jsx
@@ -98,18 +98,17 @@ const prefs = new gadgets.Prefs(),
 
         this.errorFlag = true;
         this.isLoading = false;
-        this.ready();
-
       } else {
         // show wait message while Storage initializes
         this.props.showMessage( "Please wait while your google sheet is loaded." );
 
         this.loadFonts();
         this.setVerticalAlignment();
-
         this.initRiseGoogleSheet();
         this.logConfiguration();
       }
+
+      this.ready();
 
     },
 
@@ -231,7 +230,6 @@ const prefs = new gadgets.Prefs(),
 
       if ( this.isLoading ) {
         this.isLoading = false;
-        this.ready();
       } else {
         // in case refresh fixed previous error
         this.errorFlag = false;
@@ -280,9 +278,9 @@ const prefs = new gadgets.Prefs(),
 
       if ( this.isLoading ) {
         this.isLoading = false;
-        this.ready();
       } else {
         if ( !this.viewerPaused ) {
+          this.cancelPUDTimer();
           this.done();
         }
       }
@@ -317,6 +315,11 @@ const prefs = new gadgets.Prefs(),
       } );
 
       Common.loadFonts( fontSettings );
+    },
+
+    cancelPUDTimer: function() {
+      clearTimeout( this.pudTimer );
+      this.pudTimer = null;
     },
 
     startPUDTimer: function() {


### PR DESCRIPTION
## Description
Report `ready` to Viewer without waiting on receiving a response or error from sheets handlers. 

**Note**
In the previous deployment the Widget uses latest widget common release, but the `viewer_id` and `env` fields were missing from BQ table. This was causing POST requests to BQ to fail. This has now been corrected, the fields have been added. 

## Motivation and Context
Viewer sets a 60 second expiry on receiving `ready` from Widget. If it doesn't receive it, it reloads the Widget up to 30 times. Given the widget previously waited on receiving response/error from Sheets request before reporting `ready` and now applies a random delay to execute Sheets request, sometimes the Viewer expiry happened before the Sheets request/response occurred. This was causing the Widget to never appear. 

## How Has This Been Tested?
With a staged version of Widget in https://apps.risevision.com/editor/workspace/25cc9250-e962-4d5d-bf66-0432074a9c6e?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f, tested in Preview and on display. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
