### PR TITLE
Always respond with cached sheet data immediately

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "gsap": "~1.18.5",
     "jquery": "~3.3.1",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.3.65",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.12.2",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#e95369f8",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.3",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.3.0",
     "responsive-fixed-data-table": "https://github.com/Rise-Vision/responsive-fixed-data-table.git#^3.1.0"
@@ -51,6 +51,7 @@
     "angular-ui-router": "^0.2.18",
     "jquery": "~3.3.1",
     "lodash": "~4.17.4",
-    "rv-common-style": "v1.3.65"
+    "rv-common-style": "v1.3.65",
+    "widget-common": "e95369f8"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "gsap": "~1.18.5",
     "jquery": "~3.3.1",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.3.65",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#e95369f8",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.12.3",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.3",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.3.0",
     "responsive-fixed-data-table": "https://github.com/Rise-Vision/responsive-fixed-data-table.git#^3.1.0"
@@ -51,7 +51,6 @@
     "angular-ui-router": "^0.2.18",
     "jquery": "~3.3.1",
     "lodash": "~4.17.4",
-    "rv-common-style": "v1.3.65",
-    "widget-common": "e95369f8"
+    "rv-common-style": "v1.3.65"
   }
 }


### PR DESCRIPTION
## Description
Upon initial instantiation/startup of rise-google-sheet , if cached data is available, respond to consumer with it immediately regardless of it possibly being expired (based on refresh value).

See https://github.com/Rise-Vision/widget-common/pull/166 for full changes and info

## Motivation and Context
Addresses #330 

## How Has This Been Tested?
Staged widget to use this widget-common commit and used charles proxy to target local version so I could manipulate refresh value to test scenarios. Tested with copy of client presentation on preview and display - https://apps.risevision.com/editor/workspace/2d617704-1050-4303-a2c4-beda72965145?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
